### PR TITLE
Use rds module & CMK in complete example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
-- feature: VPC used in example
-- Feature: Use a CMK in the complete example
+- feature: Use a CMK in the complete example
 - Use rds module in the complete example
 - feat: Add scan for python code and dependencies.
 - feat: Add keypair pub/priv example
+- feat: use policy & role modules in complete example
+
+## [1.0.4] - 2022-08-04
+### Description
+- feature: Use a CMK in the complete example
+- Use rds module in the complete example
+
 
 ## [1.0.3] - 2022-06-24
 ### Description
--fix: secrets manager rotation code
--added: mysql instance, vpc, endpoint, security groups and policies to test rotation
--fix: lambda vpc checkov flag
+- fix: secrets manager rotation code
+- added: mysql instance, vpc, endpoint, security groups and policies to test rotation
+- fix: lambda vpc checkov flag
 
 ## [1.0.2] - 2022-06-06
 ### Description
@@ -36,7 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Feature: Secrets version
 - feature: Secrets policy
 
-[Unreleased]: https://github.com/boldlink/terraform-aws-secretsmanager/compare/1.0.2...HEAD
+[Unreleased]: https://github.com/boldlink/terraform-aws-secretsmanager/compare/1.0.4...HEAD
+
+[1.0.4]: https://github.com/boldlink/terraform-aws-secretsmanager/releases/tag/1.0.4
 
 [1.0.3]: https://github.com/boldlink/terraform-aws-secretsmanager/releases/tag/1.0.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 ## [Unreleased]
-- feature: Use a CMK in the complete example
-- Use rds module in the complete example
 - feat: Add scan for python code and dependencies.
 - feat: Add keypair pub/priv example
 - feat: use policy & role modules in complete example

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ module "minimum" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ module "minimum" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.20.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
 
 ## Modules
 

--- a/examples/binary/README.md
+++ b/examples/binary/README.md
@@ -18,7 +18,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
 
 ## Modules

--- a/examples/binary/README.md
+++ b/examples/binary/README.md
@@ -18,7 +18,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.20.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
 
 ## Modules

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -28,7 +28,7 @@
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_lambda_kms"></a> [lambda\_kms](#module\_lambda\_kms) | boldlink/kms/aws | 1.1.0 |
-| <a name="module_mysql"></a> [mysql](#module\_mysql) | boldlink/rds/aws | 1.0.9 |
+| <a name="module_mysql"></a> [mysql](#module\_mysql) | boldlink/rds/aws | 1.1.0 |
 | <a name="module_rds_kms"></a> [rds\_kms](#module\_rds\_kms) | boldlink/kms/aws | 1.1.0 |
 | <a name="module_rotation_vpc"></a> [rotation\_vpc](#module\_rotation\_vpc) | git::https://github.com/boldlink/terraform-aws-vpc.git | 2.0.3 |
 | <a name="module_secret_rotation"></a> [secret\_rotation](#module\_secret\_rotation) | ./../../ | n/a |
@@ -45,7 +45,6 @@
 | [aws_lambda_function.mysql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_security_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
-| [aws_security_group.mysql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_vpc_endpoint.rotation_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [random_password.mysql_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [archive_file.lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -27,6 +27,9 @@
 
 | Name | Source | Version |
 |------|--------|---------|
+| <a name="module_lambda_kms"></a> [lambda\_kms](#module\_lambda\_kms) | boldlink/kms/aws | 1.1.0 |
+| <a name="module_mysql"></a> [mysql](#module\_mysql) | boldlink/rds/aws | 1.0.9 |
+| <a name="module_rds_kms"></a> [rds\_kms](#module\_rds\_kms) | boldlink/kms/aws | 1.1.0 |
 | <a name="module_rotation_vpc"></a> [rotation\_vpc](#module\_rotation\_vpc) | git::https://github.com/boldlink/terraform-aws-vpc.git | 2.0.3 |
 | <a name="module_secret_rotation"></a> [secret\_rotation](#module\_secret\_rotation) | ./../../ | n/a |
 
@@ -34,17 +37,11 @@
 
 | Name | Type |
 |------|------|
-| [aws_db_instance.mysql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
-| [aws_db_subnet_group.mysql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
 | [aws_iam_policy.mysql_lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_attachment.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_iam_policy_attachment.mysql_lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_iam_role.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.enhanced_monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.lambda_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_kms_alias.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
-| [aws_kms_key.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_lambda_function.mysql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_lambda_permission.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
 | [aws_security_group.lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -56,7 +53,6 @@
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.mysql_lambda_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,7 +20,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.20.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
 
 ## Modules

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -20,7 +20,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.3.2 |
 
 ## Modules

--- a/examples/complete/data.tf
+++ b/examples/complete/data.tf
@@ -16,6 +16,7 @@ data "archive_file" "lambda" {
 
 data "aws_iam_policy_document" "assume_role_policy" {
   statement {
+    sid     = "GrantAssumeRolePermission"
     actions = ["sts:AssumeRole"]
 
     principals {
@@ -27,36 +28,9 @@ data "aws_iam_policy_document" "assume_role_policy" {
   }
 }
 
-data "aws_iam_policy_document" "mysql_lambda_policy" {
-  #checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
-  statement {
-    actions = [
-      "ec2:CreateNetworkInterface",
-      "ec2:DeleteNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DetachNetworkInterface",
-    ]
-    resources = ["*", ]
-  }
-  statement {
-    actions = [
-      "secretsmanager:DescribeSecret",
-      "secretsmanager:GetSecretValue",
-      "secretsmanager:PutSecretValue",
-      "secretsmanager:UpdateSecretVersionStage",
-    ]
-    resources = [
-      "arn:${data.aws_partition.current.partition}:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:*",
-    ]
-  }
-  statement {
-    actions   = ["secretsmanager:GetRandomPassword"]
-    resources = ["*", ]
-  }
-}
-
 data "aws_iam_policy_document" "monitoring" {
   statement {
+    sid = "GrantAssumeRolePermission"
     actions = [
       "sts:AssumeRole",
     ]

--- a/examples/complete/locals.tf
+++ b/examples/complete/locals.tf
@@ -1,6 +1,7 @@
 locals {
   account_id       = data.aws_caller_identity.current.account_id
   partition        = data.aws_partition.current.partition
+  region           = data.aws_region.current.name
   name             = "example-complete-secret"
   filename         = "mysql-lambda.zip"
   cidr_block       = "192.168.0.0/16"
@@ -53,7 +54,7 @@ locals {
           "secretsmanager:UpdateSecretVersionStage",
         ],
         Resource = [
-          "arn:${data.aws_partition.current.partition}:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:*",
+          "arn:${local.partition}:secretsmanager:${local.region}:${local.account_id}:secret:*",
         ]
       },
       {

--- a/examples/complete/locals.tf
+++ b/examples/complete/locals.tf
@@ -19,7 +19,7 @@ locals {
       Version = "2012-10-17",
       Statement = [
         {
-          Sid    = "EnablePermissions",
+          Sid    = "GetSecretValuePermission",
           Effect = "Allow",
           Principal = {
             AWS = "arn:${local.partition}:iam::${local.account_id}:root"
@@ -29,4 +29,42 @@ locals {
         }
       ]
   })
+  lambda_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "GiveSpecificNetworkInterfacePermissions",
+        Effect = "Allow",
+        Action = [
+          "ec2:CreateNetworkInterface",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DetachNetworkInterface",
+        ],
+        Resource = ["*"]
+      },
+      {
+        Sid    = "GiveSpecificSecretPermissions",
+        Effect = "Allow",
+        Action = [
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:PutSecretValue",
+          "secretsmanager:UpdateSecretVersionStage",
+        ],
+        Resource = [
+          "arn:${data.aws_partition.current.partition}:secretsmanager:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret:*",
+        ]
+      },
+      {
+        Sid      = "AllowGetRandomPassword",
+        Action   = ["secretsmanager:GetRandomPassword"],
+        Effect   = "Allow",
+        Resource = ["*"]
+    }]
+  })
+  tags = {
+    environment        = "examples"
+    "user::CostCenter" = "terraform-registry"
+  }
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -26,8 +26,8 @@ module "secret_rotation" {
 module "rotation_vpc" {
   source               = "git::https://github.com/boldlink/terraform-aws-vpc.git?ref=2.0.3"
   name                 = "${local.name}-vpc"
-  account              = data.aws_caller_identity.current.account_id
-  region               = data.aws_region.current.name
+  account              = local.account_id
+  region               = local.region
   tag_env              = local.tag_env
   cidr_block           = local.cidr_block
   enable_dns_support   = true
@@ -39,7 +39,7 @@ module "rotation_vpc" {
 
 resource "aws_vpc_endpoint" "rotation_vpc" {
   vpc_id            = module.rotation_vpc.id
-  service_name      = "com.amazonaws.${data.aws_region.current.name}.secretsmanager"
+  service_name      = "com.amazonaws.${local.region}.secretsmanager"
   vpc_endpoint_type = "Interface"
   subnet_ids        = flatten(module.rotation_vpc.private_subnet_id)
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -44,44 +44,11 @@ resource "aws_vpc_endpoint" "rotation_vpc" {
   subnet_ids        = flatten(module.rotation_vpc.private_subnet_id)
 
 
-  security_group_ids = [
-    aws_security_group.mysql.id,
-  ]
+  security_group_ids = module.mysql.sg_id
+
 
   private_dns_enabled = true
   tags                = local.tags
-}
-
-resource "aws_security_group" "mysql" {
-  name        = "${local.name}-security-group"
-  description = "Allow inbound traffic"
-  vpc_id      = module.rotation_vpc.id
-
-  ingress {
-    cidr_blocks     = [local.cidr_block]
-    description     = "mysql ingress rule"
-    from_port       = 0
-    prefix_list_ids = []
-    protocol        = "-1"
-    security_groups = [aws_security_group.lambda.id]
-    self            = false
-    to_port         = 0
-  }
-  egress {
-    cidr_blocks     = [local.cidr_block]
-    description     = "mysql egress rule"
-    from_port       = 0
-    prefix_list_ids = []
-    protocol        = "-1"
-    security_groups = []
-    self            = false
-    to_port         = 0
-  }
-
-  tags = local.tags
-  lifecycle {
-    create_before_destroy = true
-  }
 }
 
 resource "aws_security_group" "lambda" {

--- a/examples/complete/mysql_db.tf
+++ b/examples/complete/mysql_db.tf
@@ -33,7 +33,7 @@ module "mysql" {
   deletion_protection                 = false
   vpc_id                              = module.rotation_vpc.id
   assume_role_policy                  = data.aws_iam_policy_document.monitoring.json
-  policy_arn                          = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+  policy_arn                          = "arn:${local.partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
   major_engine_version                = "8.0"
 
   security_group_ingress = [

--- a/examples/complete/mysql_db.tf
+++ b/examples/complete/mysql_db.tf
@@ -15,7 +15,7 @@ resource "random_password" "mysql_password" {
 
 module "mysql" {
   source                              = "boldlink/rds/aws"
-  version                             = "1.0.9"
+  version                             = "1.1.0"
   engine                              = "mysql"
   instance_class                      = "db.t3.micro"
   subnet_ids                          = flatten(module.rotation_vpc.private_subnet_id)
@@ -26,18 +26,17 @@ module "mysql" {
   port                                = 3306
   iam_database_authentication_enabled = true
   multi_az                            = true
-  #create_security_group               = true
-  enabled_cloudwatch_logs_exports = ["general", "error", "slowquery"]
-  create_monitoring_role          = true
-  monitoring_interval             = 30
-  deletion_protection             = false
-  vpc_id                          = module.rotation_vpc.id
-  vpc_security_group_ids          = [aws_security_group.mysql.id]
-  assume_role_policy              = data.aws_iam_policy_document.monitoring.json
-  policy_arn                      = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
-  major_engine_version            = "8.0"
+  create_security_group               = true
+  enabled_cloudwatch_logs_exports     = ["general", "error", "slowquery"]
+  create_monitoring_role              = true
+  monitoring_interval                 = 30
+  deletion_protection                 = false
+  vpc_id                              = module.rotation_vpc.id
+  assume_role_policy                  = data.aws_iam_policy_document.monitoring.json
+  policy_arn                          = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+  major_engine_version                = "8.0"
 
-  /*security_group_ingress = [
+  security_group_ingress = [
     {
       description = "inbound rds traffic"
       from_port   = 0
@@ -54,5 +53,5 @@ module "mysql" {
       protocol    = -1
       cidr_blocks = [local.cidr_block]
     }
-  ]*/
+  ]
 }

--- a/examples/complete/mysql_db.tf
+++ b/examples/complete/mysql_db.tf
@@ -1,10 +1,11 @@
-resource "aws_db_subnet_group" "mysql" {
-  name       = "${local.name}-dbsubnet-group"
-  subnet_ids = flatten(module.rotation_vpc.private_subnet_id)
-
-  tags = {
-    Name = local.name
-  }
+module "rds_kms" {
+  source              = "boldlink/kms/aws"
+  version             = "1.1.0"
+  description         = "key for mysql"
+  create_kms_alias    = true
+  enable_key_rotation = true
+  alias_name          = "alias/${local.name}-rds-key"
+  tags                = local.tags
 }
 
 resource "random_password" "mysql_password" {
@@ -12,34 +13,46 @@ resource "random_password" "mysql_password" {
   special = false
 }
 
-resource "aws_db_instance" "mysql" {
-  allocated_storage                   = 20
+module "mysql" {
+  source                              = "boldlink/rds/aws"
+  version                             = "1.0.9"
   engine                              = "mysql"
-  engine_version                      = "8.0.28"
   instance_class                      = "db.t3.micro"
-  db_name                             = "exampledb"
-  identifier                          = "${local.name}-instance"
+  subnet_ids                          = flatten(module.rotation_vpc.private_subnet_id)
+  name                                = "exampledb"
   username                            = "admin"
   password                            = random_password.mysql_password.result
-  skip_final_snapshot                 = true
-  multi_az                            = true
-  storage_encrypted                   = true
+  kms_key_id                          = module.rds_kms.arn
+  port                                = 3306
   iam_database_authentication_enabled = true
-  enabled_cloudwatch_logs_exports     = ["general", "error", "slowquery"]
-  auto_minor_version_upgrade          = true
-  monitoring_interval                 = 30
-  monitoring_role_arn                 = aws_iam_role.monitoring.arn
-  vpc_security_group_ids              = [aws_security_group.mysql.id]
-  db_subnet_group_name                = aws_db_subnet_group.mysql.name
-}
+  multi_az                            = true
+  #create_security_group               = true
+  enabled_cloudwatch_logs_exports = ["general", "error", "slowquery"]
+  create_monitoring_role          = true
+  monitoring_interval             = 30
+  deletion_protection             = false
+  vpc_id                          = module.rotation_vpc.id
+  vpc_security_group_ids          = [aws_security_group.mysql.id]
+  assume_role_policy              = data.aws_iam_policy_document.monitoring.json
+  policy_arn                      = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+  major_engine_version            = "8.0"
 
-resource "aws_iam_role" "monitoring" {
-  name               = "${local.name}-enhanced-monitoring-role"
-  assume_role_policy = data.aws_iam_policy_document.monitoring.json
-  description        = "enhanced monitoring iam role for rds instance."
-}
-
-resource "aws_iam_role_policy_attachment" "enhanced_monitoring" {
-  role       = aws_iam_role.monitoring.name
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+  /*security_group_ingress = [
+    {
+      description = "inbound rds traffic"
+      from_port   = 0
+      to_port     = 0
+      protocol    = "-1"
+      cidr_blocks = [local.cidr_block]
+    }
+  ]
+  security_group_egress = [
+    {
+      description = "Rule to allow outbound traffic"
+      from_port   = 0
+      to_port     = 0
+      protocol    = -1
+      cidr_blocks = [local.cidr_block]
+    }
+  ]*/
 }

--- a/examples/key-value/README.md
+++ b/examples/key-value/README.md
@@ -17,7 +17,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.20.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
 
 ## Modules
 

--- a/examples/key-value/README.md
+++ b/examples/key-value/README.md
@@ -17,7 +17,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.24.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.25.0 |
 
 ## Modules
 


### PR DESCRIPTION
# Description

This PR aims to use the RDS module in complete example and also use a CMK

## Features/Fixes/Patches/Changes list:

Please check the [CHANGELOG.md](https://github.com/boldlink/terraform-aws-secretsmanager/blob/feature/use-rds-module/CHANGELOG.md#104---2022-08-04)

## Checklists:
### PR Owners Checklist:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
* [x] Have you checked there aren't open [Pull Requests](../../../pulls) of upstream or parallel code that will cause conflicts?
* [x] Have you updated the `CHANGELOG.md`?
* [x] Have you updated the `README.md`(s)?
* [x] OWNER: Does your submission pass?
    * [x] Pre-commit (attach logs/print screen to this PR)
    * [x] Checkov/terrascan (attach logs/print screen to this PR)
    * [x] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your core changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### PR Reviewers Checklists?
* [ ] Are all your comments/changes resolved?
* [ ] Are you happy with the OWNER checklists and additional information provided?
* [ ] Does your review tests pass?
    * [ ] Terraform resources examples build/destroy successfully with Terraform 0.14.11 minimum?


<details><summary><b>Checkov scan results:</b></summary>

```bash


       _               _              
   ___| |__   ___  ___| | _______   __
  / __| '_ \ / _ \/ __| |/ / _ \ \ / /
 | (__| | | |  __/ (__|   < (_) \ V / 
  \___|_| |_|\___|\___|_|\_\___/ \_/  
                                      
By bridgecrew.io | version: 2.1.32 
Update available 2.1.32 -> 2.1.83
Run pip3 install -U checkov to update 


terraform scan results:

Passed checks: 34, Failed checks: 0, Skipped checks: 1

Check: CKV_AWS_49: "Ensure no IAM policies documents allow "*" as a statement's actions"
	PASSED for resource: aws_iam_policy_document.assume_role_policy
	File: /examples/complete/data.tf:17-29
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_43
Check: CKV_AWS_108: "Ensure IAM policies does not allow data exfiltration"
	PASSED for resource: aws_iam_policy_document.assume_role_policy
	File: /examples/complete/data.tf:17-29
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-data-exfiltration
Check: CKV_AWS_1: "Ensure IAM policies that allow full "*-*" administrative privileges are not created"
	PASSED for resource: aws_iam_policy_document.assume_role_policy
	File: /examples/complete/data.tf:17-29
	Guide: https://docs.bridgecrew.io/docs/iam_23
Check: CKV_AWS_110: "Ensure IAM policies does not allow privilege escalation"
	PASSED for resource: aws_iam_policy_document.assume_role_policy
	File: /examples/complete/data.tf:17-29
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-does-not-allow-privilege-escalation
Check: CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
	PASSED for resource: aws_iam_policy_document.assume_role_policy
	File: /examples/complete/data.tf:17-29
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-permissions-management-resource-exposure-without-constraint
Check: CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
	PASSED for resource: aws_iam_policy_document.assume_role_policy
	File: /examples/complete/data.tf:17-29
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-write-access-without-constraint
Check: CKV_AWS_107: "Ensure IAM policies does not allow credentials exposure"
	PASSED for resource: aws_iam_policy_document.assume_role_policy
	File: /examples/complete/data.tf:17-29
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-credentials-exposure
Check: CKV_AWS_49: "Ensure no IAM policies documents allow "*" as a statement's actions"
	PASSED for resource: aws_iam_policy_document.monitoring
	File: /examples/complete/data.tf:31-43
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_43
Check: CKV_AWS_108: "Ensure IAM policies does not allow data exfiltration"
	PASSED for resource: aws_iam_policy_document.monitoring
	File: /examples/complete/data.tf:31-43
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-data-exfiltration
Check: CKV_AWS_1: "Ensure IAM policies that allow full "*-*" administrative privileges are not created"
	PASSED for resource: aws_iam_policy_document.monitoring
	File: /examples/complete/data.tf:31-43
	Guide: https://docs.bridgecrew.io/docs/iam_23
Check: CKV_AWS_110: "Ensure IAM policies does not allow privilege escalation"
	PASSED for resource: aws_iam_policy_document.monitoring
	File: /examples/complete/data.tf:31-43
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-does-not-allow-privilege-escalation
Check: CKV_AWS_109: "Ensure IAM policies does not allow permissions management / resource exposure without constraints"
	PASSED for resource: aws_iam_policy_document.monitoring
	File: /examples/complete/data.tf:31-43
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-permissions-management-resource-exposure-without-constraint
Check: CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints"
	PASSED for resource: aws_iam_policy_document.monitoring
	File: /examples/complete/data.tf:31-43
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-write-access-without-constraint
Check: CKV_AWS_107: "Ensure IAM policies does not allow credentials exposure"
	PASSED for resource: aws_iam_policy_document.monitoring
	File: /examples/complete/data.tf:31-43
	Guide: https://docs.bridgecrew.io/docs/ensure-iam-policies-do-not-allow-credentials-exposure
Check: CKV_AWS_45: "Ensure no hard-coded secrets exist in lambda environment"
	PASSED for resource: aws_lambda_function.mysql
	File: /examples/complete/lambda.tf:1-26
	Guide: https://docs.bridgecrew.io/docs/bc_aws_secrets_3
Check: CKV_AWS_115: "Ensure that AWS Lambda function is configured for function-level concurrent execution limit"
	PASSED for resource: aws_lambda_function.mysql
	File: /examples/complete/lambda.tf:1-26
	Guide: https://docs.bridgecrew.io/docs/ensure-that-aws-lambda-function-is-configured-for-function-level-concurrent-execution-limit
Check: CKV_AWS_173: "Check encryption settings for Lambda environmental variable"
	PASSED for resource: aws_lambda_function.mysql
	File: /examples/complete/lambda.tf:1-26
	Guide: https://docs.bridgecrew.io/docs/bc_aws_serverless_5
Check: CKV_AWS_117: "Ensure that AWS Lambda function is configured inside a VPC"
	PASSED for resource: aws_lambda_function.mysql
	File: /examples/complete/lambda.tf:1-26
	Guide: https://docs.bridgecrew.io/docs/ensure-that-aws-lambda-function-is-configured-inside-a-vpc-1
Check: CKV_AWS_50: "X-ray tracing is enabled for Lambda"
	PASSED for resource: aws_lambda_function.mysql
	File: /examples/complete/lambda.tf:1-26
	Guide: https://docs.bridgecrew.io/docs/bc_aws_serverless_4
Check: CKV_AWS_61: "Ensure AWS IAM policy does not allow assume role permission across all services"
	PASSED for resource: aws_iam_role.lambda
	File: /examples/complete/lambda.tf:45-48
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_45
Check: CKV_AWS_60: "Ensure IAM role allows only specific services or principals to assume it"
	PASSED for resource: aws_iam_role.lambda
	File: /examples/complete/lambda.tf:45-48
	Guide: https://docs.bridgecrew.io/docs/bc_aws_iam_44
Check: CKV_AWS_40: "Ensure IAM policies are attached only to groups or roles (Reducing access management complexity may in-turn reduce opportunity for a principal to inadvertently receive or retain excessive privileges.)"
	PASSED for resource: aws_iam_policy_attachment.lambda
	File: /examples/complete/lambda.tf:55-59
	Guide: https://docs.bridgecrew.io/docs/iam_16-iam-policy-privileges-1
Check: CKV_AWS_63: "Ensure no IAM policies documents allow "*" as a statement's actions"
	PASSED for resource: aws_iam_policy.mysql_lambda_policy
	File: /examples/complete/lambda.tf:61-65
	Guide: https://docs.bridgecrew.io/docs/iam_48
Check: CKV_AWS_62: "Ensure IAM policies that allow full "*-*" administrative privileges are not created"
	PASSED for resource: aws_iam_policy.mysql_lambda_policy
	File: /examples/complete/lambda.tf:61-65
	Guide: https://docs.bridgecrew.io/docs/iam_47
Check: CKV_AWS_40: "Ensure IAM policies are attached only to groups or roles (Reducing access management complexity may in-turn reduce opportunity for a principal to inadvertently receive or retain excessive privileges.)"
	PASSED for resource: aws_iam_policy_attachment.mysql_lambda_policy
	File: /examples/complete/lambda.tf:67-71
	Guide: https://docs.bridgecrew.io/docs/iam_16-iam-policy-privileges-1
Check: CKV_AWS_24: "Ensure no security groups allow ingress from 0.0.0.0:0 to port 22"
	PASSED for resource: aws_security_group.lambda
	File: /examples/complete/main.tf:54-83
	Guide: https://docs.bridgecrew.io/docs/networking_1-port-security
Check: CKV_AWS_25: "Ensure no security groups allow ingress from 0.0.0.0:0 to port 3389"
	PASSED for resource: aws_security_group.lambda
	File: /examples/complete/main.tf:54-83
	Guide: https://docs.bridgecrew.io/docs/networking_2
Check: CKV_AWS_260: "Ensure no security groups allow ingress from 0.0.0.0:0 to port 80"
	PASSED for resource: aws_security_group.lambda
	File: /examples/complete/main.tf:54-83
Check: CKV_AWS_23: "Ensure every security groups rule has a description"
	PASSED for resource: aws_security_group.lambda
	File: /examples/complete/main.tf:54-83
	Guide: https://docs.bridgecrew.io/docs/networking_31
Check: CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
	PASSED for resource: module.binary_string.aws_secretsmanager_secret.this
	File: /main.tf:2-12
	Calling File: /examples/binary/main.tf:6-20
	Guide: https://docs.bridgecrew.io/docs/ensure-that-secrets-manager-secret-is-encrypted-using-kms
Check: CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
	PASSED for resource: module.secret_rotation.aws_secretsmanager_secret.this
	File: /main.tf:2-12
	Calling File: /examples/complete/main.tf:2-24
	Guide: https://docs.bridgecrew.io/docs/ensure-that-secrets-manager-secret-is-encrypted-using-kms
Check: CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
	PASSED for resource: module.key_pair_string.aws_secretsmanager_secret.this
	File: /main.tf:2-12
	Calling File: /examples/key-value/main.tf:1-20
	Guide: https://docs.bridgecrew.io/docs/ensure-that-secrets-manager-secret-is-encrypted-using-kms
Check: CKV_AWS_149: "Ensure that Secrets Manager secret is encrypted using KMS CMK"
	PASSED for resource: module.minimum.aws_secretsmanager_secret.this
	File: /main.tf:2-12
	Calling File: /examples/minimum/main.tf:1-14
	Guide: https://docs.bridgecrew.io/docs/ensure-that-secrets-manager-secret-is-encrypted-using-kms
Check: CKV2_AWS_5: "Ensure that Security Groups are attached to another resource"
	PASSED for resource: aws_security_group.lambda
	File: /examples/complete/main.tf:54-83
	Guide: https://docs.bridgecrew.io/docs/ensure-that-security-groups-are-attached-to-ec2-instances-or-elastic-network-interfaces-enis
Check: CKV_AWS_116: "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
	SKIPPED for resource: aws_lambda_function.mysql
	Suppress comment:  "Ensure that AWS Lambda function is configured for a Dead Letter Queue(DLQ)"
	File: /examples/complete/lambda.tf:1-26
	Guide: https://docs.bridgecrew.io/docs/ensure-that-aws-lambda-function-is-configured-for-a-dead-letter-queue-dlq
```
</details>